### PR TITLE
Adds a config option to auto-set text color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.1.0
+
+- Add a new option `setTextColor` which also allows it to set the appropriate white or black text color to contrast with the background color.
+
 # v1.0.0
 
 - **Official release.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v1.1.0
 
-- Add a new option `setTextColor` which also allows it to set the appropriate white or black text color to contrast with the background color.
+- Add a new option `autoTextContrast` which also allows it to set the appropriate white or black text color to contrast with the background color.
 
 # v1.0.0
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,24 @@ const el = document.createElement('div')
 setRandomBgColor(el)
 ```
 
+### Prevent animated transitions
+
+Pass in an object to the second argument like this:
+
+```js
+setRandomBgColor(null, { disallowTransition: true })
+```
+
+### Set text color
+
+By default we don't adjust text colors. However, you might want us to, because some of the colors have poor contrast if you just use white the entire time. Use the following option:
+
+```js
+setRandomBgColor(null, { setTextColor: true })
+```
+
+The behavior of this is to set the `color` style of the same element where the `background-color` is changing. If you use this option you may want to set the `color: inherit` CSS property of child elements to make sure that they pick up changes to the text color.
+
 ### Override transition style
 
 This isn't a setting. Change it via CSS instead.
@@ -59,12 +77,4 @@ This isn't a setting. Change it via CSS instead.
 body {
   transition: background-color 500ms ease-in-out !important;
 }
-```
-
-### Prevent animated transitions
-
-Pass in an object to the second argument like this:
-
-```js
-setRandomBgColor(null, { disallowTransition: true })
 ```

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ Pass in an object to the second argument like this:
 setRandomBgColor(null, { disallowTransition: true })
 ```
 
-### Set text color
+### Automatically adjust text contrast
 
 By default we don't adjust text colors. However, you might want us to, because some of the colors have poor contrast if you just use white the entire time. Use the following option:
 
 ```js
-setRandomBgColor(null, { setTextColor: true })
+setRandomBgColor(null, { autoTextContrast: true })
 ```
 
 The behavior of this is to set the `color` style of the same element where the `background-color` is changing. If you use this option you may want to set the `color: inherit` CSS property of child elements to make sure that they pick up changes to the text color.

--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@
         }
         var color = selectRandomColor();
         el.style.backgroundColor = color;
-        if (options.setTextColor === true) {
+        if (options.autoTextContrast === true) {
           if (color === '#fcea10' || color === '#ffda00') {
             el.style.color = 'black';
           } else {

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,8 @@
    * @param {Object} options - accepts the following properties:
    *    disallowTransition - if false, does not override
    *      the CSS transition property. Defaults to `true`
+   *    autoTextContrast - if true, attempts to automatically
+   *      adjust text color to contrast with background color
    * @return undefined (this is a side effect)
    */
   function setRandomBgColor (selector, options) {

--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,15 @@
         } else if (css) {
           el.style.transition = css;
         }
-        el.style.backgroundColor = selectRandomColor();
+        var color = selectRandomColor();
+        el.style.backgroundColor = color;
+        if (options.setTextColor === true) {
+          if (color === '#fcea10' || color === '#ffda00') {
+            el.style.color = 'black';
+          } else {
+            el.style.color = 'white';
+          }
+        }
       })
     }
   }

--- a/test/index.html
+++ b/test/index.html
@@ -29,8 +29,8 @@
     document.body.appendChild(example)
     window.setInterval(function () {
       BIFFUD.setRandomBgColor(null)
-      BIFFUD.setRandomBgColor('h1', { disallowTransition: true, setTextColor: true })
-      BIFFUD.setRandomBgColor(example, { setTextColor: true })
+      BIFFUD.setRandomBgColor('h1', { disallowTransition: true, autoTextContrast: true })
+      BIFFUD.setRandomBgColor(example, { autoTextContrast: true })
     }, 1000)
   </script>
 </body>

--- a/test/index.html
+++ b/test/index.html
@@ -7,7 +7,6 @@
   <title>@biffud/random-bg-color test</title>
   <style>
     body {
-      color: white;
       font-family: sans-serif;
       margin: 0;
       padding: 20px;
@@ -22,16 +21,16 @@
   </style>
 </head>
 <body>
-  <h1>You can apply background changes to an element too</h1>
+  <h1>You can apply background changes to an element</h1>
   <script src="../src/index.js"></script>
   <script>
     var example = document.createElement('p')
     example.textContent = 'You can even do it with elements created dynamically'
     document.body.appendChild(example)
     window.setInterval(function () {
-      BIFFUD.setRandomBgColor(null, { disallowTransition: false })
-      BIFFUD.setRandomBgColor('h1', { disallowTransition: true })
-      BIFFUD.setRandomBgColor(example)
+      BIFFUD.setRandomBgColor(null)
+      BIFFUD.setRandomBgColor('h1', { disallowTransition: true, setTextColor: true })
+      BIFFUD.setRandomBgColor(example, { setTextColor: true })
     }, 1000)
   </script>
 </body>

--- a/test/test.js
+++ b/test/test.js
@@ -56,6 +56,15 @@ describe('setRandomBgColor', function () {
     expect(el.style.transition).to.equal('background-color 120ms');
   });
 
+  it('adjusts the text contrast if `autoTextContrast` is set', function () {
+    const el = document.createElement('div');
+    setRandomBgColor(el, { autoTextContrast: true });
+
+    // We can't deterministically set a background color on this test,
+    // so test to make sure that color property is set correctly
+    expect(el.style.color).to.match(/white|black/);
+  });
+
   // Reset the global object and JSDOM after each test
   afterEach(function () {
     global.document = undefined;


### PR DESCRIPTION
This PR adds a config option, `setTextColor` (default is false), when true, will also add the CSS style `color: white` or `color: black`, whichever has the best contrast for readability. (Basically, just the two lightest shades of yellow will have black text.)

For this to work properly I recommend not setting the `color` property on any elements that are children of the parent element that use the parent’s background, or set `color: inherit;`.

This solution is easiest, but it doesn’t take into account edge cases such as:

- Default text color being something other than black or white
- A design decision to use black text on most background colors, only using white when it’s low contrast for black text + dark background color

If approved, I’ll add tests, and publish a minor version bump.